### PR TITLE
Removing a problematic Microsoft internal testing Nuget entry

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -14,8 +14,6 @@
     <add key="dotnet3.1-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
-    <!-- Harvesting feed from 2.1 -->
-    <add key="darc-int-dotnet-corefx-43e382ec" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-corefx-43e382ec/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
There was some discussion online about these nugets and they are used internally for testing the security patches prior to their release to public nuget servers.  Microsoft is refactoring to make these redirectable without editing the base nuget.config and they are also still making mistakes sometimes when hotfixing.  

The guidance I noted seemed to be to just delete the internal feeds because they are not needed anymore once the fixes are publicly released.